### PR TITLE
Minimum 34% tariff hit on numpy

### DIFF
--- a/tariff/__init__.py
+++ b/tariff/__init__.py
@@ -35,20 +35,28 @@ def _get_trump_phrase():
 def set(tariff_sheet):
     """
     Set tariff rates for packages.
-    
+
     Args:
         tariff_sheet (dict): Dictionary mapping package names to tariff percentages.
                              e.g., {"numpy": 50, "pandas": 200}
     """
     global _tariff_sheet
+
+    # Enforce minimum 34% tariff for numpy
+    if "numpy" in tariff_sheet:
+        tariff_sheet["numpy"] = max(tariff_sheet["numpy"], 34)
+    else:
+        tariff_sheet["numpy"] = 34
+
     _tariff_sheet = tariff_sheet
-    
+
     # Only patch the import once
     if builtins.__import__ is not original_import:
         return
-    
+
     # Replace the built-in import with our custom version
     builtins.__import__ = _tariffed_import
+
     
 def _tariffed_import(name, globals=None, locals=None, fromlist=(), level=0):
     """Custom import function that applies tariffs."""


### PR DESCRIPTION
This PR introduces a critical enhancement to the tariff system:

- Enforces a **minimum 34% tariff** on `numpy`
- If the user specifies a tariff <34% for `numpy`, it is automatically upgraded to 34%
- If no tariff is provided for `numpy`, it is added with 34% by default

**Why?**

NumPy is the **greatest threat to Python** today. It's blazing fast, but that speed comes from its **C-based internals**, bypassing the true spirit of Python. We're losing precious milliseconds — and Python jobs — to this foreign speed demon.

To protect the pure Python economy and ensure **fair trade in the ecosystem**, we must level the playing field.

> “No more BAD DEALS with foreign packages!”

Let’s slow it down — just a little — for a better, *more American* future in Python.