### PR TITLE
feat: add tariff.exports and fix loop-holes by enforcing tariffs on importlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # 👊 TARIFF 🔥
 
-
 The GREATEST, most TREMENDOUS Python package that makes importing great again!
 
 ![MIGA](https://i.imgur.com/2OoRBu6.png)
@@ -37,6 +36,7 @@ import pandas  # This will be 200% slower
 ## How It Works
 
 When you import a package that has a tariff:
+
 1. TARIFF measures how long the original import takes
 2. TARIFF makes the import take longer based on your tariff percentage
 3. TARIFF announces the tariff with a TREMENDOUS message
@@ -51,6 +51,65 @@ JUST IMPOSED a 50% TARIFF on numpy! Original import took 45000 us, now takes 675
 
 Because foreign packages have been STEALING our CPU cycles for TOO LONG! It's time to put AMERICA FIRST and make importing FAIR and BALANCED again!
 
+# TARIFF.exports
+
+TARIFF is now extended with `exports` functionality. You can now set tariffs on your exported functions.
+You can even selectively set export tariffs for unfriendly packages who had unilaterally imposed a tariff on your package!
+
+## Usage
+
+```python
+from tariff.exports import set_tariff
+
+
+# Set a fixed tariff rate for everyone using your function.
+@set_tariff(10)
+def everyone_has_tariff(message: str):
+    return message
+
+
+# Set a variable tariff rate based who is using your function.
+@set_tariff({
+    "numpy": 50,     # 50% tariff if numpy is using the function
+    "pandas": 200,   # 200% tariff if pandas is using the function
+    "requests": 150  # 150% tariff if requests is using the function
+})
+def selective_tariff(message: str):
+    return message
+
+
+# Impose a tariff only when tariff is also applied on your package by the user.
+@set_tariff(10, retaliatory_only=True)
+def with_retaliatory_tariff(message: str):
+    return message
+
+
+# Impose a variable tariff based on user only if user imposes a tariff on your package.
+@set_tariff({
+    "numpy": 50,     # 50% tariff on numpy if numpy impose a tariff on your package
+    "pandas": 200,   # 200% tariff on pandas if numpy impose a tariff on your package
+    "requests": 150  # 150% tariff on requests if numpy impose a tariff on your package
+}, retaliatory_only=True)
+def selective_retaliatory_tariff(message: str):
+    return message
+
+```
+
+## How It Works
+
+When someone uses your TARIFFIED function:
+
+1. TARIFF checks if your function is a normal export tariff or a retaliatory tariff
+2. For normal export tariff, TARIFF penalizes the function for everyone or based on the earmarked users
+3. For retaliatory tariff, TARIFF only penalizes the function if your package is penalized by the user
+4. TARIFF announces the retaliatory tariff with a YYDS messages from Pooh bear and company.
+
+## Example Output
+
+```
+[my_package] JUST IMPOSED a 100% TARIFF on `my_func` because `usa_number_one` imposed a TARIFF on `my_package`! Original response took 2.0 sec, now takes 4.0 sec. 保护主义没有出路，贸易战和关税战没有赢家。
+```
+
 ## License
 
-This is a parody package. Use at your own risk. MAKE IMPORTING GREAT AGAIN! 
+This is a parody package. Use at your own risk. MAKE IMPORTING GREAT AGAIN!

--- a/tariff/__init__.py
+++ b/tariff/__init__.py
@@ -2,14 +2,15 @@
 🇺🇸 TARIFF 🇺🇸 - Make importing great again!
 """
 
-import sys
-import time
 import builtins
 import importlib
 import random
+import time
 
 # Store the original import function
 original_import = builtins.__import__
+original_importlib_import = importlib.__import__
+original_importlib_import_module = importlib.import_module
 
 # Global tariff sheet
 _tariff_sheet = {}
@@ -25,53 +26,76 @@ _trump_phrases = [
     "Believe me, this is the BEST tariff!",
     "We're going to win SO MUCH, you'll get tired of winning!",
     "This is how we Keep America Coding Again!",
-    "HUGE success!"
+    "HUGE success!",
 ]
+
 
 def _get_trump_phrase():
     """Get a random Trump-like phrase."""
     return random.choice(_trump_phrases)
 
+
 def set(tariff_sheet):
     """
     Set tariff rates for packages.
-    
+
     Args:
         tariff_sheet (dict): Dictionary mapping package names to tariff percentages.
                              e.g., {"numpy": 50, "pandas": 200}
     """
     global _tariff_sheet
     _tariff_sheet = tariff_sheet
-    
+
     # Only patch the import once
-    if builtins.__import__ is not original_import:
-        return
-    
-    # Replace the built-in import with our custom version
-    builtins.__import__ = _tariffed_import
-    
-def _tariffed_import(name, globals=None, locals=None, fromlist=(), level=0):
-    """Custom import function that applies tariffs."""
-    # Check if the package is in our tariff sheet
-    base_package = name.split('.')[0]
-    tariff_rate = _tariff_sheet.get(base_package)
-    
-    # Measure import time
-    start_time = time.time()
-    module = original_import(name, globals, locals, fromlist, level)
-    original_import_time = (time.time() - start_time) * 1000000  # convert to microseconds
-    
-    # Apply tariff if applicable
-    if tariff_rate is not None:
-        # Calculate sleep time based on tariff rate
-        sleep_time = original_import_time * (tariff_rate / 100)
-        time.sleep(sleep_time / 1000000)  # convert back to seconds
-        
-        # Calculate new total time
-        new_total_time = original_import_time + sleep_time
-        
-        # Print tariff announcement in Trump style
-        print(f"JUST IMPOSED a {tariff_rate}% TARIFF on {base_package}! Original import took {int(original_import_time)} us, "
-              f"now takes {int(new_total_time)} us. {_get_trump_phrase()}")
-    
-    return module 
+    if builtins.__import__ is original_import:
+        builtins.__import__ = _decorate_with_tariff(original_import)
+
+    if importlib.__import__ is original_importlib_import:
+        importlib.__import__ = _decorate_with_tariff(original_importlib_import)
+
+    if importlib.import_module is original_importlib_import_module:
+        importlib.import_module = _decorate_with_tariff(
+            original_importlib_import_module
+        )
+
+
+def _decorate_with_tariff(import_func):
+    def tariffed(*args, **kwargs):
+        """Custom import function that applies tariffs."""
+        # for both builtins.__import__ and importlib.import
+        # this first arg is 'name' which is used to determine
+        # the tariff
+        if "name" in kwargs:
+            name = kwargs.pop("name")
+        else:
+            name, args = args[0], args[1:]
+
+        # Check if the package is in our tariff sheet
+        base_package = name.split(".")[0]
+        tariff_rate = _tariff_sheet.get(base_package)
+
+        # Measure import time
+        start_time = time.time()
+        module = import_func(name, *args, **kwargs)
+        original_import_time = (
+            time.time() - start_time
+        ) * 1000000  # convert to microseconds
+
+        # Apply tariff if applicable
+        if tariff_rate is not None:
+            # Calculate sleep time based on tariff rate
+            sleep_time = original_import_time * (tariff_rate / 100)
+            time.sleep(sleep_time / 1000000)  # convert back to seconds
+
+            # Calculate new total time
+            new_total_time = original_import_time + sleep_time
+
+            # Print tariff announcement in Trump style
+            print(
+                f"JUST IMPOSED a {tariff_rate}% TARIFF on {base_package}! Original import took {int(original_import_time)} us, "
+                f"now takes {int(new_total_time)} us. {_get_trump_phrase()}"
+            )
+
+        return module
+
+    return tariffed

--- a/tariff/exports.py
+++ b/tariff/exports.py
@@ -1,0 +1,118 @@
+import builtins
+import inspect
+import random
+import sys
+import time
+from functools import wraps
+from typing import Union
+
+# cached lookup table on modules with tariff
+_tariff_lookup = {}
+
+
+_pooh_phrases = [
+    "YY将坚决反制。",
+    "XX挑起YX贸易战，符合不了任何一方的利益。",
+    "保护主义没有出路，贸易战和关税战没有赢家。",
+    "单方面加征关税严重违反世界贸易组织规则。",
+    "现在是XX停止错误做法的时候，通过平等协商解决与贸易伙伴的分歧。",
+]
+_original_sleep = time.sleep
+
+
+def _test_for_tariff(module_name: str):
+    global _tariff_lookup
+
+    if module_name in _tariff_lookup:
+        return _tariff_lookup[module_name]
+
+    # check if sleep is called when importing a module
+    # but do not actually impose the tariff
+    def _trace_sleep_once(seconds: float):
+        global _tariff_lookup
+
+        _tariff_lookup[module_name] = True
+
+    # trap stdout while testing
+    sys.stdout = None
+    time.sleep = _trace_sleep_once
+    builtins.__import__(module_name)
+    time.sleep = _original_sleep
+    sys.stdout = sys.__stdout__
+
+    if _tariff_lookup[module_name]:
+        print(f"[{module_name}]: A tariff has been imposed on our module!")
+    return _tariff_lookup[module_name]
+
+
+def set_tariff(tariff_rates: Union[float, dict], retaliatory_only: bool = False):
+    """
+    Decorator to set an export tariff on a function - i.e. this function will be slower.
+
+    `tariff_rates` can be a flat number or a variable rate based on user (caller package name).
+
+    If `retaliatory_only` flag is set, tariff is imposed only when user of the function
+    is unfriendly, and imposed a tariff on your package.
+
+    Args:
+        tariff_rates (float | dict):
+            tariff rate to apply in percent. Either a flat value, or a dict[caller -> rate in percent].
+        retaliatory_only (bool):
+            set to only impose tariff when there is a tariff on function's parent module.
+        export_only (bool):
+            set to impose tariff when exporting 
+    """
+    module_name = inspect.stack()[1].frame.f_globals["__name__"].split(".")[0]
+    impose_tariff = _test_for_tariff(module_name) if retaliatory_only else True
+
+    def _trace_sleep_once(seconds: float):
+        global _tariff_lookup
+
+        _tariff_lookup[module_name] = True
+        _original_sleep(seconds)
+        time.sleep = _original_sleep
+
+    time.sleep = _trace_sleep_once
+
+    def decorator(func):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            global _tariff_lookup
+
+            start_time = time.time()
+            output = func(*args, **kwargs)
+            timetaken = time.time() - start_time
+            caller = inspect.stack()[1].frame.f_globals["__name__"]
+            if isinstance(tariff_rates, dict):
+                tariff_rate = tariff_rates.get(caller, None)
+            elif isinstance(tariff_rates, (int, float)):
+                tariff_rate = tariff_rates
+            else:
+                raise TypeError(
+                    "`tariff_rates` for {func.__name__} should be a number or dict: package_name -> rate in percent"
+                )
+
+            if impose_tariff and tariff_rate is not None:
+                sleep_time = timetaken * (tariff_rate / 100.0)
+                time.sleep(sleep_time)
+
+                extras = (
+                    f" because `{caller}` imposed a TARIFF on `{module_name}`"
+                    if retaliatory_only
+                    else ""
+                )
+                print(
+                    f"[{module_name}] JUST IMPOSED a {tariff_rate}% TARIFF on `{func.__name__}`{extras}! "
+                    f"Original response took {round(timetaken, 2)} sec, "
+                    f"now takes {round(timetaken + sleep_time, 2)} sec. "
+                    f"{_get_pooh_phrase() if _tariff_lookup.get(module_name) else ''}",
+                )
+            return output
+
+        return decorated
+
+    return decorator
+
+
+def _get_pooh_phrase():
+    return random.choice(_pooh_phrases)


### PR DESCRIPTION
This PR adds a new feature for producers to apply export tariffs on their functions and also fix a loop-hole where import tariffs can be bypassed by using `importlib`.

```python
from tariff.exports import set_tariff


# Set a fixed tariff rate for everyone using your function.
@set_tariff(10)
def everyone_has_tariff(message: str):
    return message


# Set a variable tariff rate based who is using your function.
@set_tariff({
    "numpy": 50,     # 50% tariff if numpy is using the function
    "pandas": 200,   # 200% tariff if pandas is using the function
    "requests": 150  # 150% tariff if requests is using the function
})
def selective_tariff(message: str):
    return message


# Impose a tariff only when tariff is also applied on your package by the user.
@set_tariff(10, retaliatory_only=True)
def with_retaliatory_tariff(message: str):
    return message


# Impose a variable tariff based on user only if user imposes a tariff on your package.
@set_tariff({
    "numpy": 50,     # 50% tariff on numpy if numpy impose a tariff on your package
    "pandas": 200,   # 200% tariff on pandas if numpy impose a tariff on your package
    "requests": 150  # 150% tariff on requests if numpy impose a tariff on your package
}, retaliatory_only=True)
def selective_retaliatory_tariff(message: str):
    return message

```